### PR TITLE
Add clock stretching in i2c_write() (no timeout for now)

### DIFF
--- a/SlowSoftI2CMaster.cpp
+++ b/SlowSoftI2CMaster.cpp
@@ -97,6 +97,8 @@ bool SlowSoftI2CMaster::i2c_write(uint8_t value) {
   setHigh(_sda);
   setHigh(_scl);
   delayMicroseconds(DELAY/2);
+  while (!digitalRead(_scl))
+    delayMicroseconds(DELAY/2);
   uint8_t ack = digitalRead(_sda);
   setLow(_scl);
   delayMicroseconds(DELAY/2);  


### PR DESCRIPTION
This was required for the Sensirion SCD30 sensor.

The maturity is 'working for me'. I can imagine the bus locking up if a slave is misbehaving (holding the clock low indefinitely). I recommend keeping this in a separate branch until a proper timeout is implemented.